### PR TITLE
AB#84748: Pracite App | Ehr Note blank disappearing

### DIFF
--- a/Sources/RichEditorView/RichEditorView.swift
+++ b/Sources/RichEditorView/RichEditorView.swift
@@ -45,6 +45,8 @@ import WebKit
     @objc optional func richEditorWillUndo(_ editor: RichEditorView)
     
     @objc optional func richEditorWillRedo(_ editor: RichEditorView)
+    
+    @objc optional func richEditorWasRestarted(_ editor: RichEditorView)
 }
 
 /// The value we hold in order to be able to set the line height before the JS completely loads.
@@ -198,13 +200,17 @@ public class RichEditorWebView: WKWebView {
         webView.scrollView.clipsToBounds = true
         addSubview(webView)
         
-        if let filePath = Bundle.module.url(forResource: "rich_editor", withExtension: "html") {
-            webView.loadFileURL(filePath, allowingReadAccessTo: filePath.deletingLastPathComponent())
-        }
+        loadHtmlFile()
         
         tapRecognizer.addTarget(self, action: #selector(viewWasTapped))
         tapRecognizer.delegate = self
         addGestureRecognizer(tapRecognizer)
+    }
+    
+    private func loadHtmlFile() {
+        if let filePath = Bundle.module.url(forResource: "rich_editor", withExtension: "html") {
+            webView.loadFileURL(filePath, allowingReadAccessTo: filePath.deletingLastPathComponent())
+        }
     }
     
     // MARK: - Rich Text Editing
@@ -757,5 +763,18 @@ public class RichEditorWebView: WKWebView {
     open override func resignFirstResponder() -> Bool {
         blur()
         return true
+    }
+    
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        delegate?.richEditorWasRestarted?(self)
+        loadHtmlFile()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.webView.reload()
+            if self.html.count > self.contentHTML.count {
+                self.setHTML(self.html)
+            } else {
+                self.setHTML(self.contentHTML)
+            }
+        }
     }
 }

--- a/Sources/RichEditorView/RichEditorView.swift
+++ b/Sources/RichEditorView/RichEditorView.swift
@@ -766,6 +766,10 @@ public class RichEditorWebView: WKWebView {
     }
     
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        // Need to revisit this solution:
+        // - check why the process is terminated
+        // - check if the loading of the html/js file can be
+        // tracked instead of adding an arbitrary delay
         delegate?.richEditorWasRestarted?(self)
         loadHtmlFile()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {


### PR DESCRIPTION
- When the content of the WebView is cleaned up by process termination, reload the html/js file and set the contentHtml (user edited) or html (content fetched) whichever is bigger
- Also creating a new method to let know the client that the webview process was terminated